### PR TITLE
Separate CLI "business logic" from CLI script himself

### DIFF
--- a/__mocks__/signale.js
+++ b/__mocks__/signale.js
@@ -1,0 +1,19 @@
+const EventEmitter = require('events');
+
+const signale = jest.genMockFromModule('signale');
+
+signale.emitter = new EventEmitter();
+
+// Stub every function
+for (const property in signale) {
+	if (Object.prototype.hasOwnProperty.call(signale, property)) {
+		const value = signale[property];
+		if (typeof value === 'function') {
+			signale[property] = function (args) {
+				this.emitter.emit(`signale_${property}`, args);
+			};
+		}
+	}
+}
+
+module.exports = signale;

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+const meow = require('meow');
+
+const main = require('.');
+
+const cli = meow(`
+	Usage:
+	  $ mas-piano-validator <input>
+`);
+
+main(cli.input);

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ async function main(input) {
 		spinner: 'balloon2'
 	}).start();
 	if (input.length === 0) {
-		signale.error('Specify at least one path');
+		signale.error('Specify at least one path!');
 		return;
 	}
 	// TODO: Handle other args

--- a/index.js
+++ b/index.js
@@ -21,7 +21,14 @@ async function main(input) {
 	}
 	// TODO: Handle other args
 	const normalizedInput = path.normalize(input[0]);
-	const result = await processPath(normalizedInput);
+	let result = null;
+	try {
+		result = await processPath(normalizedInput);
+	} catch (error) {
+		spinner.stop();
+		signale.error(error.message);
+		return;
+	}
 	spinner.stop();
 	signale.info(validate.prettify(result));
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "version": "0.1.0",
     "main": "index.js",
     "bin": {
-        "mas-piano-validator": "index.js",
-        "mas-piano-validator-cli": "index.js"
+        "mas-piano-validator": "cli.js",
+        "mas-piano-validator-cli": "cli.js"
     },
     "license": "MIT",
     "dependencies": {
@@ -49,6 +49,7 @@
         }
     ],
     "files": [
+        "cli.js",
         "schema",
         "index.d.ts"
     ],

--- a/test.js
+++ b/test.js
@@ -69,4 +69,18 @@ describe('Testing CLI\'s "business logic"', () => {
 		// The passed string must span on multiple lines
 		expect(result.split(EOL).length > 1).toBeTruthy();
 	});
+
+	it('should return appropriate message when the file specified is not a json file', async () => {
+		const result = await new Promise((resolve, reject) => {
+			emitter.on('signale_error', args => {
+				resolve(args);
+			});
+			// After set timeout reject the promise
+			setTimeout(() => reject(new Error('Timeout reached!')), timeout);
+
+			main(['index.js']);
+		});
+		// The passed string must span on multiple lines
+		expect(result).toStrictEqual('The path received did not point to JSON files.');
+	});
 });

--- a/test.js
+++ b/test.js
@@ -2,6 +2,6 @@ const execa = require('execa');
 
 describe('Spawning the CLI in an other process', () => {
 	it('should do stuff', async () => {
-		await execa('./index.js', ['./examples/example.json']).stdout.pipe(process.stdout);
+		await execa('./cli.js', ['./examples/example.json']).stdout.pipe(process.stdout);
 	});
 });

--- a/test.js
+++ b/test.js
@@ -1,7 +1,72 @@
+const {EOL} = require('os');
+
 const execa = require('execa');
+const signale = require('signale');
+
+const main = require('.');
 
 describe('Spawning the CLI in an other process', () => {
 	it('should do stuff', async () => {
 		await execa('./cli.js', ['./examples/example.json']).stdout.pipe(process.stdout);
+	});
+});
+
+describe('Testing CLI\'s "business logic"', () => {
+	// "emitter" is defined in the manual mock
+	const {emitter} = signale;
+	const timeout = 2000;
+
+	it('should return appropriate message when no input is specified', async () => {
+		const result = await new Promise((resolve, reject) => {
+			emitter.on('signale_error', args => {
+				resolve(args);
+			});
+
+			// After 1 sec. reject the promise
+			setTimeout(() => reject(new Error('Timeout reached!')), timeout);
+
+			main([]);
+		});
+		expect(result).toStrictEqual('Specify at least one path!');
+	});
+
+	it('should return appropriate message when a valid input file is specified', async () => {
+		const result = await new Promise((resolve, reject) => {
+			emitter.on('signale_info', args => {
+				resolve(args);
+			});
+			// After set timeout reject the promise
+			setTimeout(() => reject(new Error('Timeout reached!')), timeout);
+
+			main(['examples/example.json']);
+		});
+		expect(result).toStrictEqual('This file is a valid Monika After Story piano song!');
+	});
+
+	it('should return appropriate message when a invalid input file is specified', async () => {
+		const result = await new Promise((resolve, reject) => {
+			emitter.on('signale_info', args => {
+				resolve(args);
+			});
+			// After set timeout reject the promise
+			setTimeout(() => reject(new Error('Timeout reached!')), timeout);
+
+			main(['examples/invalidsong.json']);
+		});
+		expect(result).toStrictEqual('This file is NOT a valid Monika After Story piano song.');
+	});
+
+	it('should return appropriate message when a directory is specified', async () => {
+		const result = await new Promise((resolve, reject) => {
+			emitter.on('signale_info', args => {
+				resolve(args);
+			});
+			// After set timeout reject the promise
+			setTimeout(() => reject(new Error('Timeout reached!')), timeout);
+
+			main(['examples']);
+		});
+		// The passed string must span on multiple lines
+		expect(result.split(EOL).length > 1).toBeTruthy();
 	});
 });


### PR DESCRIPTION
The benefit of this: "business logic" of the CLI is unit testable in a much easier way than with spawning a child process for the CLI command.

Still, a test that checks the correctness of the spawn should be in place.